### PR TITLE
Remediation Upgrade activesupport to version 4.1.11 or later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem "activesupport", ">= 4.1.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (6.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
@@ -28,9 +31,9 @@ GEM
     ffi (1.12.2-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (204)
+    github-pages (206)
       github-pages-health-check (= 1.16.1)
-      jekyll (= 3.8.5)
+      jekyll (= 3.8.7)
       jekyll-avatar (= 0.7.0)
       jekyll-coffeescript (= 1.1.1)
       jekyll-commonmark-ghpages (= 0.1.6)
@@ -69,7 +72,7 @@ GEM
       mercenary (~> 0.3)
       minima (= 2.5.1)
       nokogiri (>= 1.10.4, < 2.0)
-      rouge (= 3.13.0)
+      rouge (= 3.19.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)
       addressable (~> 2.3)
@@ -83,7 +86,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (3.8.7)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -199,7 +202,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.14.1)
+    minitest (5.14.1)
     multipart-post (2.1.1)
     nokogiri (1.10.9-x64-mingw32)
       mini_portile2 (~> 2.4.0)
@@ -212,7 +215,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.13.0)
+    rouge (3.19.0)
     ruby-enum (0.8.0)
       i18n
     rubyzip (2.3.0)
@@ -227,18 +230,21 @@ GEM
       faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.2)
-      concurrent-ruby (~> 1.0)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  activesupport (>= 4.1.11)
   github-pages
   tzinfo-data
 

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: About Me
+permalink: /about/
 ---
 
 ## Bio


### PR DESCRIPTION
Known security vulnerabilities detected
Dependency activesupport 	Version < 4.1.11 	Upgrade to ~> 4.1.11
Defined in Gemfile.lock
Vulnerabilities
CVE-2015-3227 Moderate severity